### PR TITLE
URL encode query string.

### DIFF
--- a/app/src/main/java/co/pxhouse/sas/android/activity/AssistActivity.kt
+++ b/app/src/main/java/co/pxhouse/sas/android/activity/AssistActivity.kt
@@ -132,7 +132,8 @@ class AssistActivity : Activity() {
         providers.firstOrNull { it.id() == providerId } ?: providers[0]
 
     private fun searchFor(query: CharSequence) {
-        showUri(this, String.format(findSelectedProvider().url(), query))
+        val queryEncoded = Uri.encode(query.toString())
+        showUri(this, String.format(findSelectedProvider().url(), queryEncoded))
     }
 
     private fun showUri(c: Context, uri: String) {


### PR DESCRIPTION
Some search engines require the query string to be URL encoded (e.g. Quant, Startpage).